### PR TITLE
ci: add Claude code review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,40 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    # Repo secrets are not available to PRs from forks; skip them.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request as a senior Dart/Flutter engineer. Focus on:
+            - Correctness bugs and edge cases in the changed code
+            - API misuse and error-handling gaps
+            - Security issues (credential handling, injection, unsafe file I/O)
+            - Backwards compatibility for existing users of this package
+
+            Use `gh pr comment` for overall feedback and
+            `mcp__github_inline_comment__create_inline_comment` (with confirmed: true)
+            for line-specific issues. Only post GitHub comments — do not submit
+            review text as plain messages. Be concise; skip pure style nits.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Adds an automated PR code review workflow using anthropics/claude-code-action@v1, authenticated with the Claude subscription OAuth token (secret already configured).

This must land on the default branch before the action will review PRs — it validates that the workflow file on a PR branch matches the default branch's copy. PRs #18 and #19 carry an identical copy and get reviewed once this merges.