### PR TITLE
ci: severity-classified sticky review comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,20 +21,36 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request as a senior Dart/Flutter engineer. Focus on:
-            - Correctness bugs and edge cases in the changed code
-            - API misuse and error-handling gaps
-            - Security issues (credential handling, injection, unsafe file I/O)
-            - Backwards compatibility for existing users of this package
+            Review this pull request as a senior Dart/Flutter engineer.
 
-            Use `gh pr comment` for overall feedback and
-            `mcp__github_inline_comment__create_inline_comment` (with confirmed: true)
-            for line-specific issues. Only post GitHub comments — do not submit
-            review text as plain messages. Be concise; skip pure style nits.
+            Classify every finding by severity and lead each one with its
+            label:
+            - **Critical** — bugs, broken behavior, data loss, security
+              flaws. Only Critical findings block merging.
+            - **Medium** — real but non-blocking improvements; the team may
+              table these as tracked follow-ups.
+            - **Low** — style, polish, minor hardening.
+
+            Before raising a finding, read the PR's existing comments and
+            review threads (`gh pr view <n> --comments`). Do not re-raise a
+            finding the author has already refuted or explicitly tabled
+            there unless you have new evidence. When claiming a control-flow
+            gap (e.g. a missing try/finally), read the entire enclosing
+            function first and cite the line numbers that demonstrate it.
+
+            Focus on correctness bugs and edge cases, API misuse,
+            error-handling gaps, security issues, and backwards
+            compatibility for existing users. Skip pure style nits.
+
+            Use `gh pr comment` for the summary and
+            `mcp__github_inline_comment__create_inline_comment` (with
+            confirmed: true) for line-specific issues. Only post GitHub
+            comments — do not submit review text as plain messages.
           claude_args: |
             --model claude-sonnet-4-6
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Updates the automated review workflow:

- Findings are classified **Critical / Medium / Low**; per our review policy, only Critical blocks merging and Medium/Low may be tabled.
- The reviewer reads existing PR comments and threads before raising findings, and must cite line numbers when claiming control-flow gaps — prevents re-raising refuted findings across re-reviews.
- `use_sticky_comment: true`: re-reviews update one comment instead of stacking new ones.

Note: the review action skips on this PR itself (workflow file differs from main until merged) — that's its anti-tamper validation working as intended.