### PR TITLE
fix: atomic restore write and pid-qualified temp file

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,20 +21,36 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request as a senior Dart/Flutter engineer. Focus on:
-            - Correctness bugs and edge cases in the changed code
-            - API misuse and error-handling gaps
-            - Security issues (credential handling, injection, unsafe file I/O)
-            - Backwards compatibility for existing users of this package
+            Review this pull request as a senior Dart/Flutter engineer.
 
-            Use `gh pr comment` for overall feedback and
-            `mcp__github_inline_comment__create_inline_comment` (with confirmed: true)
-            for line-specific issues. Only post GitHub comments — do not submit
-            review text as plain messages. Be concise; skip pure style nits.
+            Classify every finding by severity and lead each one with its
+            label:
+            - **Critical** — bugs, broken behavior, data loss, security
+              flaws. Only Critical findings block merging.
+            - **Medium** — real but non-blocking improvements; the team may
+              table these as tracked follow-ups.
+            - **Low** — style, polish, minor hardening.
+
+            Before raising a finding, read the PR's existing comments and
+            review threads (`gh pr view <n> --comments`). Do not re-raise a
+            finding the author has already refuted or explicitly tabled
+            there unless you have new evidence. When claiming a control-flow
+            gap (e.g. a missing try/finally), read the entire enclosing
+            function first and cite the line numbers that demonstrate it.
+
+            Focus on correctness bugs and edge cases, API misuse,
+            error-handling gaps, security issues, and backwards
+            compatibility for existing users. Skip pure style nits.
+
+            Use `gh pr comment` for the summary and
+            `mcp__github_inline_comment__create_inline_comment` (with
+            confirmed: true) for line-specific issues. Only post GitHub
+            comments — do not submit review text as plain messages.
           claude_args: |
             --model claude-sonnet-4-6
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/lib/src/shared/android_baseline_yaml.dart
+++ b/lib/src/shared/android_baseline_yaml.dart
@@ -39,18 +39,7 @@ String? writeReleaseVersionToAndroidYaml(
   // Write to a temp file and rename over the original: a failed write
   // (disk full, permissions) can then never corrupt the config, and the
   // original error propagates without a doomed in-place rescue attempt.
-  final tempFile = File('$yamlPath.tmp');
-  try {
-    tempFile.writeAsStringSync(content);
-    tempFile.renameSync(yamlPath);
-  } on FileSystemException {
-    try {
-      tempFile.deleteSync();
-    } on FileSystemException {
-      // Best-effort cleanup; the original config is untouched either way.
-    }
-    rethrow;
-  }
+  _atomicWrite(yamlPath, content);
   return originalContent;
 }
 
@@ -58,5 +47,23 @@ void restoreAndroidYaml(
   String originalContent, {
   String yamlPath = kDefaultAndroidCodePushYamlPath,
 }) {
-  File(yamlPath).writeAsStringSync(originalContent);
+  _atomicWrite(yamlPath, originalContent);
+}
+
+/// Writes [content] to [path] via a pid-qualified temp file and an atomic
+/// rename, so a failed or concurrent write can never leave the target
+/// truncated.
+void _atomicWrite(String path, String content) {
+  final tempFile = File('$path.$pid.tmp');
+  try {
+    tempFile.writeAsStringSync(content);
+    tempFile.renameSync(path);
+  } on FileSystemException {
+    try {
+      tempFile.deleteSync();
+    } on FileSystemException {
+      // Best-effort cleanup; the target file is untouched either way.
+    }
+    rethrow;
+  }
 }


### PR DESCRIPTION
Closes out the checkpoint-lineage items tabled (Medium/Low) from the PR #19 reviews:

- **Atomic restore** (Medium): `restoreAndroidYaml` now uses the same temp-file+rename pattern as the stamp write — a failed restore previously wrote in place and could truncate the config, a worse outcome than the stamped state.
- **pid-qualified temp file** (Low): parallel `fcp codepush release` runs in one worktree (e.g. a CI matrix building apk and appbundle) no longer collide on the temp filename.

Also syncs `.github/workflows/claude-review.yml` with main's severity-classified sticky-comment version so this lineage's PRs are reviewed under the same policy.